### PR TITLE
add support for multiplex signal parsing and syntax highlighting

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,40 +1,44 @@
 # Changelog
-
-# 1.0.0: 
-- Initial release
-
-# 1.0.1:
-- Updated package description
-
-# 1.0.2:
-- Fixed comment wrapping
-- Fixed scientific notation in min/max and factor/offset
-- Updated package metadata
-
-# 1.0.3:
-- Updated first line matching
-
-# 1.1.0:
-- Added basic snippets
-  
-# 1.2.0
-- Promoted to internal language server
-- Serves as a parser and throws basic parser and lexer errors
-
-# 1.2.1 
-- Fixed vscode_ignore to exclude node_modules
-
-# 1.2.2
-- Added more useful errors and warnings
-- Fixed line number that error occurs on when present
-- Changed when parse occurs (now on save)
-
-# 1.2.3
-- Fixed crashing issue that prevented parsing
-- Added option to silence warnings from undefined objects
+ 
+# 2.1.0
+- Added support for multiplex signal parsing and syntax highlighting
+- Reversed changelog order
 
 # 2.0.0
 - Restructure of entire extension
 - Added DBCLib to contain all components of dbc file
 - Separated client and server code
 - Added react-based side window that shows basic preview of messages & signals
+
+# 1.2.3
+- Fixed crashing issue that prevented parsing
+- Added option to silence warnings from undefined objects
+
+# 1.2.2
+- Added more useful errors and warnings
+- Fixed line number that error occurs on when present
+- Changed when parse occurs (now on save)
+
+# 1.2.1 
+- Fixed vscode_ignore to exclude node_modules
+
+# 1.2.0
+- Promoted to internal language server
+- Serves as a parser and throws basic parser and lexer errors
+
+# 1.1.0:
+- Added basic snippets
+  
+# 1.0.3:
+- Updated first line matching
+
+# 1.0.2:
+- Fixed comment wrapping
+- Fixed scientific notation in min/max and factor/offset
+- Updated package metadata
+
+# 1.0.1:
+- Updated package description
+
+# 1.0.0: 
+- Initial release

--- a/dbcLib/src/dbc/signal.ts
+++ b/dbcLib/src/dbc/signal.ts
@@ -29,7 +29,8 @@ export class Signal {
                        Min: number, 
                        Max: number, 
                        Unit: string,
-                       Receivers: string[]){
+                       Receivers: string[],
+                       MultiplexIndicator: string | null = null){
         this.name = Name;
         this.startBit = Start;
         this.bitSize = Size;
@@ -46,6 +47,7 @@ export class Signal {
         this.attributes = new Map();
         this.lineNum = lineNo;
         this.clsType = "signal";
+        this.multiplexIndicator = MultiplexIndicator;
     }
 
     public name: string;
@@ -64,6 +66,7 @@ export class Signal {
     public attributes: Map<string,Attribute>;
     public lineNum: number;
     public clsType: string;
+    public multiplexIndicator: string | null; // null: no multiplex, 'M': multiplexor, 'mX': multiplexed signal
 }
 
 export class SignalType{

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"url": "https://github.com/lharri73/DBC-Language-Syntax"
 	},
 	"license": "GPL-2.0-only",
-	"version": "2.0.0",
+    "version": "2.1.0",
 	"publisher": "lharri73",
 	"engines": {
 		"vscode": "^1.43.0"

--- a/server/dbc.jison
+++ b/server/dbc.jison
@@ -48,6 +48,8 @@ const db = new dbclib.Database();
 %token DECIMAL
 // %token DBC_WORD
 %token ENDOFFILE
+%token MULTIPLEXOR
+%token MULTIPLEXED
 
 %%
 
@@ -210,22 +212,31 @@ signals
         $$.set($2.name, $2);
     };
 signal
-    : SG UNSAFE_WORD /*multiplexer*/ COLON DECIMAL VBAR DECIMAL AT 
+    : SG UNSAFE_WORD multiplex_indicator COLON DECIMAL VBAR DECIMAL AT 
       byte_order signal_val_type OPEN_PAREN number COMMA number CLOSE_PAREN
       OPEN_BRACK number VBAR number CLOSE_BRACK QUOTED_STRING receivers EOL {
           $$ = new dbclib.Signal(yylineno,
-                          /*name:  */$2, 
-                          /*start: */Number($4), 
-                          /*size:  */Number($6),
-                          /*order: */$8,
-                          /*type:  */$9,
-                          /*factor:*/$11,
-                          /*offset:*/$13,
-                          /*min:   */$16,
-                          /*max:   */$18,
-                          /*unit:  */$20,
-                          /*recs:  */$21);
+                          /*name:           */$2, 
+                          /*start:          */Number($5), 
+                          /*size:           */Number($7),
+                          /*order:          */$9,
+                          /*type:           */$10,
+                          /*factor:         */$12,
+                          /*offset:         */$14,
+                          /*min:            */$17,
+                          /*max:            */$19,
+                          /*unit:           */$21,
+                          /*recs:           */$22,
+                          /*multiplexInd:   */$3);
       };
+
+multiplex_indicator
+    : %empty {$$ = null;}
+    | multiplex_token {$$ = $1;};
+
+multiplex_token
+    : MULTIPLEXOR {$$ = 'M';}
+    | MULTIPLEXED {$$ = $1;};
 
 byte_order
     : DECIMAL {

--- a/server/dbc.lex
+++ b/server/dbc.lex
@@ -61,6 +61,8 @@ DEFINER         (?![a-zA-Z])
 "VAL_TABLE_"{DEFINER}               {return "VAL_TABLE"}
 "VECTOR_XXX"{DEFINER}               {return "VECTOR_XXX"}
 "VERSION"                           {return "VERSION"}
+"M"{DEFINER}                        {return "MULTIPLEXOR"}
+"m"{DIGIT}+{DEFINER}                {yytext = yytext; return "MULTIPLEXED";}
 
 // punctuation
 "|"                             {return "VBAR"}

--- a/syntaxSrc/dbcLang.yml
+++ b/syntaxSrc/dbcLang.yml
@@ -162,15 +162,17 @@ repository:
           match: ","
 
     patterns:
-      - match: "^\\s*(SG_)\\s*(\\w*)\\s*(:?)\\s*(.*?[+-])?\\s*(\\(.*\\))?\\s*(\\[.*\\])?\\s*(\".*\")?\\s*((?(7).*|))$"
+      - match: "^\\s*(SG_)\\s*(\\w*)\\s*((M|m\\d+)\\s*)?(:?)\\s*(.*?[+-])?\\s*(\\(.*\\))?\\s*(\\[.*\\])?\\s*(\".*\")?\\s*((?(9).*|))$"
         captures:
           1:
             name: keyword.control.signal.dbc
           2: 
             name: variable.parameter.sigName.dbc meta.signal.name.dbc
-          3:
-            name: punctuation.qualifier.dbc
           4:
+            name: meta.signal.multiplexIndicator.dbc
+          5:
+            name: punctuation.qualifier.dbc
+          6:
             patterns:
               - match: "(\\d*)(\\|?)(\\d*)(@?)([01]?)([+-]?)"
                 captures:
@@ -186,7 +188,7 @@ repository:
                     name: constant.numeric.binary.dbc meta.signal.byteOrder.dbc
                   6: 
                     name: punctuation.sign.dbc meta.signal.signed.dbc
-          5:
+          7:
             patterns:
               - match: "(\\(?)((?>-?\\d+\\.?\\d*E?\\+?\\d*)?)\\s*(,?)\\s*((?>-?\\d+\\.?\\d*E?\\+?\\d*)?)\\s*(\\)?)"
                 captures:
@@ -200,7 +202,7 @@ repository:
                     name: constant.numeric.decimal.dbc meta.signal.offset.dbc
                   5:
                     name: punctuation.definition.factorOffset.end.dbc
-          6:
+          8:
             patterns:
               - match: "(\\[?)(-?\\d+\\.?\\d*E?\\+?\\d*)(\\|?)(-?\\d+\\.?\\d*E?\\+?\\d*)(\\]?)"
                 captures:
@@ -214,11 +216,11 @@ repository:
                     name: constant.numeric.decimal.dbc meta.signal.maximum.dbc
                   5:
                     name: punctuation.definition.minMax.end.dbc
-          7:
+          9:
             name: meta.signal.unit.dbc
             patterns:
               - include: "#strings"
-          8:
+          10:
             patterns:
             - name: variable.language.nodeName.dbc
               match: "\\w+"


### PR DESCRIPTION
Implements #4 

Before:
Syntax highlighting for multiplex signals is buggy. Signals (and messages after that) don't show up in preview window.
![img_v3_02u5_830256ac-9830-464d-a9b5-d7f0daf838bg](https://github.com/user-attachments/assets/e48fd33c-86f5-49ff-927d-c7ad50e14263)

After:
![img_v3_02u5_98b7968a-0a16-45c7-8157-477e00268cdg](https://github.com/user-attachments/assets/1ab9593f-6749-473d-8eae-8351a4b7ea65)

Attached is the sample dbc:
```dbc
VERSION ""

NS_ :

BS_:

BU_:

BO_ 100 VehicleStatus: 8 Vector__XXX
  SG_ StatusCode M : 0|8@1+ (1,0) [0|255] "" ECU1
  SG_ Speed m0 : 8|16@1+ (0.1,0) [0|6553.5] "km/h" ECU1
  SG_ RPM m0 : 24|16@1+ (1,0) [0|65535] "rpm" ECU1
  SG_ Temperature m1 : 8|8@1+ (1,-40) [-40|215] "°C" ECU1
  SG_ Pressure m1 : 16|8@1+ (0.1,0) [0|25.5] "kPa" ECU1
  SG_ FuelLevel m2 : 8|8@1+ (0.5,0) [0|127.5] "L" ECU1

BO_ 200 SensorData: 8 Vector__XXX
  SG_ SensorID : 0|16@1+ (1,0) [0|65535] "" ECU2
  SG_ SensorValue : 16|32@1+ (0.001,0) [0|4294967.295] "V" ECU2
```